### PR TITLE
Remove global socket timeout, fix error in add_header

### DIFF
--- a/eSELECTplus_Python_API_v1.1.0/eSELECTplus_Python_API/mpgClasses.py
+++ b/eSELECTplus_Python_API_v1.1.0/eSELECTplus_Python_API/mpgClasses.py
@@ -23,10 +23,9 @@ class mpgHttpsPost:
                         #print ("Request URL is: [" + requestUrl + "]") 
                         #print ("Data to send : " + self.__data)
                         requestObj = urllib2.Request(requestUrl, self.__data)
-                        socket.setdefaulttimeout(self.__timeout)
                         requestObj.add_header("USER-AGENT", self.__agent)
-                        requestObj.add_header("CONTENT-TYPE:", "text/xml")
-                        responsePacket = urllib2.urlopen(requestObj)
+                        requestObj.add_header("CONTENT-TYPE", "text/xml")
+                        responsePacket = urllib2.urlopen(requestObj, timeout=self.__timeout)
                         response = responsePacket.read()
 
                         #print ("******\n Got response of: " + response + "\n******")


### PR DESCRIPTION
Removed a colon from a header name passed to add_header(). The colon causes current versions of python to throw an exception.

Also, rather than setting a global socket timeout, passed the timeout argument to urlopen(). That allows this code to have its timeout without affecting other parts of the application.